### PR TITLE
implement verify_proof function to verify inclusion 

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,15 @@
+extern crate sha2;
+use sha2::{Digest, Sha256};
+
+pub fn hash_combined(a: &Vec<u8>, b: &Vec<u8>) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(a);
+    hasher.update(b);
+    hasher.finalize().to_vec()
+}
+
+pub fn hash_value(data: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod crypto;
 pub mod merkle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use merkle_tree::crypto::hash_value;
 use merkle_tree::merkle::MerkleTree;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,18 @@
-use merkle_tree::crypto::hash_value;
-use merkle_tree::merkle::MerkleTree;
+use hex::encode;
+use merkle_tree::merkle::*;
 
 fn main() {
     let merkle_tree = MerkleTree::new(&[1, 2, 3, 4, 5]);
-    println!("{:?}", merkle_tree.get_root_node());
-    println!("{:?}", merkle_tree.inclusion_proof(1, 2));
+    println!("{}", encode(merkle_tree.get_root_node().get_hash()));
+    let proof = merkle_tree.inclusion_proof(1, 2);
+    println!("{:?}", proof);
+    println!(
+        "{}",
+        verify_proof(
+            1,
+            2,
+            proof.expect("aaaa"),
+            merkle_tree.get_root_node().get_hash()
+        )
+    );
 }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -35,6 +35,14 @@ impl MerkleNode {
             right: Some(Box::new(merkle_right.clone())),
         }
     }
+
+    pub fn get_hash(&self) -> Vec<u8> {
+        self.hash.clone()
+    }
+
+    pub fn get_hash_string(&self) -> String {
+        String::from_utf8(self.hash.clone()).expect("Invalid utf8 bytes on hash")
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,7 +1,6 @@
 use crate::crypto::hash_combined;
 use crate::crypto::hash_value;
 
-use sha2::{Digest, Sha256};
 use std::f64;
 
 /// The MerkleNode data structure represents the root of a binary MerkleTree

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,4 +1,5 @@
-extern crate sha2;
+use crate::crypto::hash_combined;
+use crate::crypto::hash_value;
 
 use sha2::{Digest, Sha256};
 use std::f64;
@@ -16,10 +17,7 @@ pub struct MerkleNode {
 impl MerkleNode {
     /// Create a new instance without any children
     pub fn new_leaf(data_block: &[u8]) -> Self {
-        let mut hasher = Sha256::new();
-        hasher.update(data_block);
-        let hash = hasher.finalize().to_vec();
-
+        let hash = hash_value(data_block);
         MerkleNode {
             hash,
             left: None,
@@ -29,10 +27,7 @@ impl MerkleNode {
     /// Create a new instance from two child nodes. Store the hash of the concatenation of the two
     /// children's hashes and a reference to each child node.k
     pub fn combine(merkle_left: &MerkleNode, merkle_right: &MerkleNode) -> Self {
-        let mut hasher = Sha256::new();
-        hasher.update(&merkle_left.hash);
-        hasher.update(&merkle_right.hash);
-        let hash = hasher.finalize().to_vec();
+        let hash = hash_combined(&merkle_left.hash, &merkle_right.hash);
 
         MerkleNode {
             hash,
@@ -134,7 +129,7 @@ impl MerkleTree {
     fn merkle_proof(root_node: &MerkleNode, index: usize, tree_height: usize) -> Vec<Vec<u8>> {
         match (&root_node.left, &root_node.right) {
             (Some(left), Some(right)) => {
-                //Each level's size is a power of 2, divide the data by two each level, depending
+                //Each level's size is divided in a power of 2 and the remainder on each level, depending
                 //on which half the element we want to prove inclusion of is at we choose left or right children
                 //of the current root and add that node's sibling to the proof.
 
@@ -157,22 +152,6 @@ impl MerkleTree {
         }
     }
 
-    /// Function to verify a Merkle proof
-    pub fn verify_proof(index: usize, data: u8, proof: Vec<Vec<u8>>, root_hash: Vec<u8>) -> bool {
-        let mut computed_hash = hash_value(&[data]);
-        let mut current_index = index;
-        for sibling_hash in proof.iter() {
-            if current_index % 2 == 0 {
-                computed_hash = hash_combined(computed_hash, sibling_hash.to_vec());
-            } else {
-                computed_hash =
-                    Sha256::digest(&[sibling_hash.clone(), computed_hash].concat()).to_vec();
-            }
-            current_index /= 2;
-        }
-        computed_hash == root_hash
-    }
-
     /// Returns the height of the tree. Because it's a full binary tree, the height is calculated
     /// by applying log2 to the ammount of leaves and ceiling the result.
     pub fn get_tree_height(&self) -> usize {
@@ -180,15 +159,18 @@ impl MerkleTree {
     }
 }
 
-fn hash_combined(a: Vec<u8>, b: Vec<u8>) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(a);
-    hasher.update(b);
-    hasher.finalize().to_vec()
-}
-
-fn hash_value(data: &[u8]) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    hasher.finalize().to_vec()
+/// Function to verify a Merkle proof
+pub fn verify_proof(index: usize, data: u8, proof: Vec<Vec<u8>>, root_hash: Vec<u8>) -> bool {
+    let mut computed_hash = hash_value(&[data]);
+    let mut current_index = index;
+    for sibling_hash in proof.iter() {
+        if current_index % 2 == 0 {
+            computed_hash = hash_combined(&computed_hash, &sibling_hash);
+        } else {
+            computed_hash =
+                Sha256::digest(&[sibling_hash.clone(), computed_hash].concat()).to_vec();
+        }
+        current_index /= 2;
+    }
+    computed_hash == root_hash
 }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -175,8 +175,7 @@ pub fn verify_proof(index: usize, data: u8, proof: Vec<Vec<u8>>, root_hash: Vec<
         if current_index % 2 == 0 {
             computed_hash = hash_combined(&computed_hash, &sibling_hash);
         } else {
-            computed_hash =
-                Sha256::digest(&[sibling_hash.clone(), computed_hash].concat()).to_vec();
+            computed_hash = hash_combined(&sibling_hash, &computed_hash);
         }
         current_index /= 2;
     }

--- a/src/tests/merkle-tests.rs
+++ b/src/tests/merkle-tests.rs
@@ -1,0 +1,7 @@
+use merkle_tree::merkle::*
+use merkle_tree::crypto::*
+
+#[cfg(test)]
+mod tests {
+    use super::*
+}

--- a/src/tests/merkle-tests.rs
+++ b/src/tests/merkle-tests.rs
@@ -1,7 +1,0 @@
-use merkle_tree::merkle::*
-use merkle_tree::crypto::*
-
-#[cfg(test)]
-mod tests {
-    use super::*
-}

--- a/tests/merkle-tests.rs
+++ b/tests/merkle-tests.rs
@@ -1,0 +1,86 @@
+use merkle_tree::crypto::*;
+use merkle_tree::merkle::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_even_merkle_tree() {
+        let data = &[1, 2, 3, 4];
+        let tree = MerkleTree::new(data);
+
+        let left_combined = hash_combined(&hash_value(&[1]), &hash_value(&[2]));
+        let right_combined = hash_combined(&hash_value(&[3]), &hash_value(&[4]));
+        assert_eq!(
+            hash_combined(&left_combined, &right_combined),
+            tree.get_root_node().get_hash()
+        )
+    }
+
+    #[test]
+    fn test_from_odd_two_level_merkle_tree() {
+        let data = &[1, 2, 3, 4, 5];
+        let tree = MerkleTree::new(data);
+
+        let left_combined = hash_combined(&hash_value(&[1]), &hash_value(&[2]));
+        let middle_combined = hash_combined(&hash_value(&[3]), &hash_value(&[4]));
+        let right_combined = hash_combined(&hash_value(&[5]), &hash_value(&[5]));
+
+        let level_2_left = hash_combined(&left_combined, &middle_combined);
+        let level_2_right = hash_combined(&right_combined, &right_combined);
+        assert_eq!(
+            hash_combined(&level_2_left, &level_2_right),
+            tree.get_root_node().get_hash()
+        )
+    }
+
+    #[test]
+    fn test_generate_proof_correctly() {
+        let data = &[1, 2, 3, 4, 5];
+        let tree = MerkleTree::new(data);
+
+        let left_combined = hash_combined(&hash_value(&[1]), &hash_value(&[2]));
+        let middle_combined = hash_combined(&hash_value(&[3]), &hash_value(&[4]));
+        let right_combined = hash_combined(&hash_value(&[5]), &hash_value(&[5]));
+
+        let _level_2_left = hash_combined(&left_combined, &middle_combined);
+        let level_2_right = hash_combined(&right_combined, &right_combined);
+
+        //proof that the value 3 is at index 2
+        let proof = tree.inclusion_proof(2, 3);
+        assert_eq!(
+            proof.expect("Proof is None"),
+            vec![hash_value(&[4]), left_combined, level_2_right]
+        )
+    }
+
+    #[test]
+    fn test_verify_proof_correctly() {
+        let data = &[1, 2, 3, 4, 5];
+        let tree = MerkleTree::new(data);
+        let proof = tree.inclusion_proof(2, 3);
+        assert!(verify_proof(
+            2,
+            3,
+            proof.expect("Proof is None"),
+            tree.get_root_node().get_hash()
+        ));
+    }
+
+    #[test]
+    fn test_verify_incorrect_proof_returns_false() {
+        let data = &[1, 2, 3, 4, 5];
+        let tree = MerkleTree::new(data);
+        let proof = tree.inclusion_proof(2, 3);
+        assert_eq!(
+            verify_proof(
+                3,
+                2,
+                proof.expect("Proof is None"),
+                tree.get_root_node().get_hash()
+            ),
+            false
+        );
+    }
+}


### PR DESCRIPTION
The function verify_proof takes a u8 value, an index, a proof, and the root of the Merkle Tree.
It returns a boolean value indicating wether or not the proof is valid.

In this PR I also corrected some comments, moved the crypto utility functions to a different file and added some prints on main.rs.