### PR TITLE
Apply feedback

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,19 +1,19 @@
 extern crate sha2;
 use sha2::{Digest, Sha256};
 
-pub type Hash = Vec<u8>;
+pub type Hash = [u8; 32];
 
 /// Concatenates two hashes and returns the hash of the result.
 pub fn hash_combined(a: &Hash, b: &Hash) -> Hash {
     let mut hasher = Sha256::new();
     hasher.update(a);
     hasher.update(b);
-    hasher.finalize().to_vec()
+    hasher.finalize().into()
 }
 
 /// Returns the hash digest of a single data slice.
 pub fn hash_value<T: AsRef<[u8]>>(data: T) -> Hash {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    hasher.finalize().to_vec()
+    hasher.finalize().into()
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -23,9 +23,8 @@ impl MerkleTree {
         }
     }
 
-    /// Returns the root node of the tree as a MerkleNode struct.
-    pub fn get_root_node(&self) -> &MerkleNode {
-        &self.root
+    pub fn root_hash(&self) -> Hash {
+        self.root.get_hash()
     }
 
     /// Given a value and it's position on the data, returns a cryptographic inclusion proof.
@@ -34,11 +33,7 @@ impl MerkleTree {
             return None;
         } else {
             let tree_height = self.get_tree_height();
-            return Some(Self::merkle_proof(
-                &self.get_root_node(),
-                index,
-                tree_height,
-            ));
+            return Some(Self::merkle_proof(&self.root, index, tree_height));
         }
     }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -22,9 +22,15 @@ impl MerkleTree {
             data: data.iter().map(|item| item.as_ref().to_vec()).collect(),
         }
     }
-
+    /// Returns the hash value of the root of the Merkle Tree
     pub fn root_hash(&self) -> Hash {
         self.root.get_hash()
+    }
+
+    /// Returns the height of the tree. Because it's a full binary tree, the height is calculated
+    /// by applying log2 to the ammount of leaves and ceiling the result.
+    pub fn get_tree_height(&self) -> usize {
+        (f64::from(self.data.len() as u32).log2().ceil()) as usize
     }
 
     /// Given a value and it's position on the data, returns a cryptographic inclusion proof.
@@ -40,6 +46,10 @@ impl MerkleTree {
     /// Recursive helper function to generate the inclusion proof:
     /// The proof that an element is in the tree is the proof that an element is
     /// on one of the sub-trees + the hash of that subtree's sibling.
+    ///
+    /// A Merkle Tree is always a full binary tree by construction, this means that every node has either
+    /// two children or none. Because of this, the path from the root to a leaf can be easily
+    /// found.
     fn merkle_proof(root_node: &MerkleNode, index: usize, tree_height: usize) -> Vec<Hash> {
         match (root_node.left(), root_node.right()) {
             (Some(left), Some(right)) => {
@@ -52,23 +62,18 @@ impl MerkleTree {
                 if index < half_size {
                     let mut proof = Self::merkle_proof(left, index, tree_height - 1);
                     proof.push(right.get_hash());
-                    return proof;
+                    proof
                 } else {
                     let mut proof = Self::merkle_proof(right, index - tree_height, tree_height - 1);
                     proof.push(left.get_hash());
-                    return proof;
+                    proof
                 }
             }
-            _ => {
+            (None, None) => {
                 vec![]
             }
+            _ => unreachable!(),
         }
-    }
-
-    /// Returns the height of the tree. Because it's a full binary tree, the height is calculated
-    /// by applying log2 to the ammount of leaves and ceiling the result.
-    pub fn get_tree_height(&self) -> usize {
-        (f64::from(self.data.len() as u32).log2().ceil()) as usize
     }
 }
 

--- a/tests/merkle-tests.rs
+++ b/tests/merkle-tests.rs
@@ -14,7 +14,7 @@ mod tests {
         let right_combined = hash_combined(&hash_value(&[3]), &hash_value(&[4]));
         assert_eq!(
             hash_combined(&left_combined, &right_combined),
-            tree.get_root_node().get_hash()
+            tree.root_hash()
         )
     }
 
@@ -31,7 +31,7 @@ mod tests {
         let level_2_right = hash_combined(&right_combined, &right_combined);
         assert_eq!(
             hash_combined(&level_2_left, &level_2_right),
-            tree.get_root_node().get_hash()
+            tree.root_hash()
         )
     }
 
@@ -64,7 +64,7 @@ mod tests {
             2,
             [3],
             proof.expect("Proof is None"),
-            tree.get_root_node().get_hash()
+            tree.root_hash()
         ));
     }
 
@@ -74,12 +74,7 @@ mod tests {
         let tree = MerkleTree::new(data);
         let proof = tree.inclusion_proof(2, [3]);
         assert_eq!(
-            verify_proof(
-                3,
-                [2],
-                proof.expect("Proof is None"),
-                tree.get_root_node().get_hash()
-            ),
+            verify_proof(3, [2], proof.expect("Proof is None"), tree.root_hash()),
             false
         );
     }
@@ -93,7 +88,7 @@ mod tests {
         let right_combined = hash_combined(&hash_value("estas"), &hash_value("bro"));
         assert_eq!(
             hash_combined(&left_combined, &right_combined),
-            tree.get_root_node().get_hash()
+            tree.root_hash()
         )
     }
 
@@ -110,7 +105,7 @@ mod tests {
         let level_2_right = hash_combined(&right_combined, &right_combined);
         assert_eq!(
             hash_combined(&level_2_left, &level_2_right),
-            tree.get_root_node().get_hash()
+            tree.root_hash()
         )
     }
 
@@ -144,7 +139,7 @@ mod tests {
             2,
             "estas",
             proof.expect("Proof is None"),
-            tree.get_root_node().get_hash()
+            tree.root_hash()
         ));
     }
 
@@ -159,7 +154,7 @@ mod tests {
                 3,
                 "estabas",
                 proof.expect("Proof is None"),
-                tree.get_root_node().get_hash()
+                tree.root_hash()
             ),
             false
         );


### PR DESCRIPTION
- pub fn get_root_node(&self) -> &MerkleNode - en este caso estás "leakeando" el tipo MerkleNode, lo que te ata a que la representación interna sea con nodos enlazados
- merkle_proof supone que el árbol es completo (supone que ambos hijos de un nodo existen, o ninguno existe). Habría que documentar por qué esto es válido.
- Hash es un Vec<u8>, lo que es raro. Generalmente los hashes producen una cantidad fija de bytes, y podemos aprovecharnos de eso para codificarlo a nivel de tipos (o sea, usar [u8; 32]/Box<[u8; 32]>).